### PR TITLE
Parse Content ID API error reason; make Error a tag-free domain value

### DIFF
--- a/error.go
+++ b/error.go
@@ -27,6 +27,39 @@ const (
 	ErrTypeUnknown      ErrorType = "unknown"
 )
 
+// Claim error reasons surfaced in a Google API error envelope's
+// errors[].reason field (domain youtubePartner.claims.*). They are exposed
+// via Error.Reason so callers can classify a claim failure by its cause.
+// This is the claims-management subset of the Content ID API error
+// reference; other domains (assets, policies, references, …) can be added
+// as needed.
+const (
+	// claims.update / claims.patch
+	ReasonAlreadyClaimed               = "alreadyClaimed"
+	ReasonChannelMonetizationSuspended = "channelMonetizationSuspended"
+	ReasonChannelNotActive             = "channelNotActive"
+	ReasonClaimIsClosed                = "claimIsClosed"
+	ReasonInvalidStatusTransition      = "invalidStatusTransition"
+	ReasonMissingOwnership             = "missingOwnership"
+	ReasonPolicyCannotBeChanged        = "policyCannotBeChanged"
+
+	// claims.insert (in addition to the shared reasons above)
+	ReasonExistingSoundRecordingOrMusicVideoClaim = "existingSoundRecordingOrMusicVideoClaim"
+	ReasonInvalidContentOwner                     = "invalidContentOwner"
+	ReasonPolicyTypeNotPermitted                  = "policyTypeNotPermitted"
+	ReasonTakedownNotPermitted                    = "takedownNotPermitted"
+	ReasonThirdPartyClaimNotAllowed               = "thirdPartyClaimNotAllowed"
+	ReasonVideoIsPrivate                          = "videoIsPrivate"
+	ReasonVideoNotOwned                           = "videoNotOwned"
+	ReasonVideoNotProcessed                       = "videoNotProcessed"
+	ReasonWrongContentType                        = "wrongContentType"
+
+	// Common errors (any method)
+	ReasonContentOwnerNotProvided  = "contentOwnerNotProvided"
+	ReasonServiceAccountNotAllowed = "serviceAccountNotAllowed"
+	ReasonInternalError            = "internalError"
+)
+
 type OAuthError string
 type ErrorType string
 
@@ -34,13 +67,40 @@ func (e OAuthError) Error() string {
 	return string(e)
 }
 
+// ErrorDetail is one entry from a Google API error envelope's errors[]
+// array (e.g. {reason: "missingOwnership", domain: "youtubePartner.claims.update"}).
+type ErrorDetail struct {
+	Domain  string `json:"domain"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+}
+
+// Error is the structured error returned for a failed YouTube API call.
+// DecodeResponse assembles it from the response body — it is a domain
+// value, not a JSON decode target, so it carries no struct tags (the two
+// wire shapes are decoded into local types inside DecodeResponse).
 type Error struct {
-	StatusCode  int       `json:"-"`
-	ErrorType   ErrorType `json:"error"`
-	Description string    `json:"error_description"`
-	Body        string    `json:"body"`
+	// StatusCode is the HTTP status of the failed response.
+	StatusCode int
+	// ErrorType is the OAuth error code, or ErrTypeUnknown for a Content ID
+	// API error (whose cause is carried in Reason instead).
+	ErrorType ErrorType
+	// Description is the human-readable message — the OAuth
+	// error_description, or the Content ID envelope's error.message.
+	Description string
+	// Body is the raw response body.
+	Body string
+	// Reason is the first errors[].reason from a Content ID API error
+	// envelope (e.g. "missingOwnership"); empty for OAuth-style errors.
+	// Compare against the Reason* constants.
+	Reason string
+	// Errors holds every detail entry from a Content ID API error envelope.
+	Errors []ErrorDetail
 }
 
 func (e Error) Error() string {
+	if e.Reason != "" {
+		return e.Reason + ": " + e.Description
+	}
 	return string(e.ErrorType) + ": " + e.Description
 }

--- a/request.go
+++ b/request.go
@@ -1,7 +1,6 @@
 package youtube
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -32,16 +31,53 @@ func DecodeResponse(res *http.Response, out interface{}) error {
 			return err
 		}
 
-		var e Error
-		if err := json.NewDecoder(bytes.NewReader(body)).Decode(&e); err == nil {
-			e.StatusCode = res.StatusCode
+		// Content ID API error envelope:
+		// {"error":{"code":..,"message":..,"errors":[{reason,domain,message}]}}.
+		// Tried first because its object-valued "error" field cannot decode
+		// into the OAuth shape below.
+		var env struct {
+			Error struct {
+				Code    int           `json:"code"`
+				Message string        `json:"message"`
+				Errors  []ErrorDetail `json:"errors"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(body, &env); err == nil &&
+			(env.Error.Code != 0 || len(env.Error.Errors) > 0) {
+			e := Error{
+				StatusCode:  res.StatusCode,
+				ErrorType:   ErrTypeUnknown,
+				Description: env.Error.Message,
+				Body:        string(body),
+				Errors:      env.Error.Errors,
+			}
+			if len(env.Error.Errors) > 0 {
+				e.Reason = env.Error.Errors[0].Reason
+			}
 			return e
 		}
 
-		e.StatusCode = res.StatusCode
-		e.ErrorType = ErrTypeUnknown
-		e.Description = string(body)
-		return e
+		// OAuth-style error: {"error":"invalid_grant","error_description":".."}.
+		var oauth struct {
+			Error       ErrorType `json:"error"`
+			Description string    `json:"error_description"`
+		}
+		if err := json.Unmarshal(body, &oauth); err == nil {
+			return Error{
+				StatusCode:  res.StatusCode,
+				ErrorType:   oauth.Error,
+				Description: oauth.Description,
+				Body:        string(body),
+			}
+		}
+
+		// Unrecognised shape (e.g. an HTML or plain-text body).
+		return Error{
+			StatusCode:  res.StatusCode,
+			ErrorType:   ErrTypeUnknown,
+			Description: string(body),
+			Body:        string(body),
+		}
 	}
 	if out == nil {
 		return nil

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,67 @@
+package youtube
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func errResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// TestDecodeResponse_ContentIDEnvelope verifies the Google API error
+// envelope (object-valued "error" with an errors[] array) is parsed into
+// the structured Reason / Errors fields.
+func TestDecodeResponse_ContentIDEnvelope(t *testing.T) {
+	body := `{"error":{"code":400,"message":"The claimed asset is not owned by the caller.","errors":[{"message":"The claimed asset is not owned by the caller.","domain":"youtubePartner.claims.update","reason":"missingOwnership"}]}}`
+
+	err := DecodeResponse(errResponse(http.StatusBadRequest, body), nil)
+	require.Error(t, err)
+
+	var ytErr Error
+	require.ErrorAs(t, err, &ytErr)
+	require.Equal(t, http.StatusBadRequest, ytErr.StatusCode)
+	require.Equal(t, ReasonMissingOwnership, ytErr.Reason)
+	require.Equal(t, "The claimed asset is not owned by the caller.", ytErr.Description)
+	require.Len(t, ytErr.Errors, 1)
+	require.Equal(t, "youtubePartner.claims.update", ytErr.Errors[0].Domain)
+	require.Equal(t, "missingOwnership: The claimed asset is not owned by the caller.", ytErr.Error())
+}
+
+// TestDecodeResponse_OAuthError verifies the OAuth-style error shape
+// (string-valued "error") still decodes into ErrorType, with no Reason.
+func TestDecodeResponse_OAuthError(t *testing.T) {
+	body := `{"error":"invalid_grant","error_description":"Bad Request"}`
+
+	err := DecodeResponse(errResponse(http.StatusBadRequest, body), nil)
+	require.Error(t, err)
+
+	var ytErr Error
+	require.ErrorAs(t, err, &ytErr)
+	require.Equal(t, http.StatusBadRequest, ytErr.StatusCode)
+	require.Empty(t, ytErr.Reason)
+	require.Equal(t, ErrTypeInvalidGrant, ytErr.ErrorType)
+}
+
+// TestDecodeResponse_Unparseable falls back to ErrTypeUnknown with the raw
+// body preserved.
+func TestDecodeResponse_Unparseable(t *testing.T) {
+	body := `not json at all`
+
+	err := DecodeResponse(errResponse(http.StatusInternalServerError, body), nil)
+	require.Error(t, err)
+
+	var ytErr Error
+	require.ErrorAs(t, err, &ytErr)
+	require.Equal(t, http.StatusInternalServerError, ytErr.StatusCode)
+	require.Equal(t, ErrTypeUnknown, ytErr.ErrorType)
+	require.Empty(t, ytErr.Reason)
+	require.Equal(t, body, ytErr.Description)
+}


### PR DESCRIPTION
## Summary

`youtube.Error` could not surface *why* a Content ID API call failed. The
Partner API returns errors in a Google envelope —
`{"error":{"code":400,"message":"…","errors":[{"reason":"missingOwnership","domain":"youtubePartner.claims.update","message":"…"}]}}`
— whose object-valued `error` field fails to decode into the OAuth-style
shape (`error` as a string), so these collapsed to `ErrTypeUnknown` with
the raw JSON in `Description`. Callers needing the `reason` (e.g. to decide
whether a failure is retryable) had to string-scrape the body.

## Changes

- **`DecodeResponse` now parses the Content ID error envelope** and exposes
  the cause via two new `Error` fields:
  - `Reason` — the first `errors[].reason` (e.g. `missingOwnership`)
  - `Errors []ErrorDetail` — every `{domain, reason, message}` entry
- **`Error` is now a tag-free domain value.** Previously it did double duty
  — both the target of `json.Decode` (OAuth shape) and a hand-assembled
  value — which forced `json:"-"` hacks on its computed fields. Now each
  wire shape (envelope, OAuth) is decoded into a *local* type and `Error`
  is built from it, so `Error` carries no struct tags at all. Parsing
  behaviour for OAuth-style and unrecognised bodies is preserved.
- `Error.Error()` leads with `Reason` when present (`missingOwnership: …`)
  and otherwise keeps the existing `ErrorType: …` form.
- `Error.Body` now consistently holds the raw response body on every error
  path (previously it was left empty on the OAuth/unknown paths).
- Added claim-management reason constants (`ReasonMissingOwnership`,
  `ReasonAlreadyClaimed`, `ReasonInvalidStatusTransition`, … plus common
  `ReasonInternalError` / `ReasonContentOwnerNotProvided` /
  `ReasonServiceAccountNotAllowed`) — the claims.* subset of the Content ID
  error reference. Other domains can be added as needed; the library stays
  policy-free (it exposes the reason; callers classify it).

## Test plan

- Added `request_test.go` (no network): the Content ID envelope parses into
  `Reason`/`Errors`/`StatusCode`; OAuth-style errors still decode into
  `ErrorType` with no `Reason`; unrecognised bodies fall back to
  `ErrTypeUnknown` with the raw body preserved.
- `go build ./...`, `go vet ./...`, `go test ./...` pass (the JWT-gated
  network tests skip without `YOUTUBE_JWT`, unchanged).
