### PR TITLE
Add ReasonInvalid: global-domain invalid-parameter error reason

### DIFF
--- a/error.go
+++ b/error.go
@@ -58,6 +58,10 @@ const (
 	ReasonContentOwnerNotProvided  = "contentOwnerNotProvided"
 	ReasonServiceAccountNotAllowed = "serviceAccountNotAllowed"
 	ReasonInternalError            = "internalError"
+	// ReasonInvalid is the global-domain rejection of an invalid request
+	// parameter value; observed on claimSearch.list for an expired or
+	// malformed pageToken.
+	ReasonInvalid = "invalid"
 )
 
 type OAuthError string


### PR DESCRIPTION
Adds the `invalid` reason constant to the common-errors group. It is the Google API global-domain rejection of an invalid request parameter value — observed in production on `claimSearch.list` when a stored `pageToken` has expired (`invalid: Invalid Value`).

Consumed by monstercat/lm's claims cron to classify an expired search cursor as terminal instead of retrying it forever (companion lm PR to follow).